### PR TITLE
Initial api

### DIFF
--- a/juju/environment.py
+++ b/juju/environment.py
@@ -1,10 +1,8 @@
-__metaclass__ = type
-
 from .configstore import ConfigStore
 from .exceptions import EnvironmentNotBootstrapped
 
 
-class Environment():
+class Environment(object):
     """Represents an environment in a Juju System.
 
     The environment may be the initial environment of the system itself.
@@ -29,3 +27,4 @@ class Environment():
 
     def status():
         # work in progress here...
+        pass

--- a/juju/system.py
+++ b/juju/system.py
@@ -1,7 +1,5 @@
-__metaclass__ = type
 
-
-class System():
+class System(object):
 
 
 	def __init__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+PyYAML==3.11
+argparse==1.2.1
+backports.ssl-match-hostname==3.4.0.2
+funcsigs==0.4
+mock==1.3.0
+nose==1.3.7
+pbr==1.4.0
+py==1.4.30
+pytest==2.7.2
+setuptools-git==1.1
+six==1.9.0
+websocket-client==0.32.0
+wsgiref==0.1.2

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1,4 +1,5 @@
 import mock
+import os
 import unittest
 
 import juju.apiclient
@@ -10,7 +11,7 @@ class TestFacade(unittest.TestCase):
         connection = mock.Mock()
         connection._rpc = mock.Mock(return_value='called')
 
-        facade = juju.apiclient.Facade(connection, "FacadeName")
+        facade = juju.apiclient.Facade(connection, 'FacadeName')
         result = facade.SomeMethod('args')
         self.assertEqual(result, 'called')
         connection._rpc.assert_called_with('FacadeName', 'SomeMethod', 'args', version=None)
@@ -19,7 +20,7 @@ class TestFacade(unittest.TestCase):
         connection = mock.Mock()
         connection._rpc = mock.Mock(return_value='called')
 
-        facade = juju.apiclient.Facade(connection, "FacadeName", 3)
+        facade = juju.apiclient.Facade(connection, 'FacadeName', 3)
         result = facade.SomeMethod('args')
         self.assertEqual(result, 'called')
         connection._rpc.assert_called_with('FacadeName', 'SomeMethod', 'args', version=3)
@@ -27,7 +28,45 @@ class TestFacade(unittest.TestCase):
 
 class TestConnection(unittest.TestCase):
 
+    def test_write_cert(self):
+        cert_text = 'some fake cert text'
+        f = juju.apiclient.Connection._write_cert(cert_text)
+        filename = f.name
+        self.assertTrue(filename.endswith('.pem'))
+        with open(filename) as cert_file:
+            content = cert_file.read()
+            self.assertEqual(content, cert_text)
+
+    def test_write_cert_removed_when_closed(self):
+        cert_text = 'some fake cert text'
+        f = juju.apiclient.Connection._write_cert(cert_text)
+        filename = f.name
+        f.close()
+        self.assertRaises(
+            OSError,
+            os.stat,
+            filename)
+
     def test_login_args(self):
         self.assertEqual(
             juju.apiclient.Connection._login_args(0, 'username', 'password', None),
-            {"AuthTag": 'username', "Password": 'password'})
+            {'AuthTag': 'username', 'Password': 'password'})
+        self.assertEqual(
+            juju.apiclient.Connection._login_args(0, 'username', 'password', 'a nonce'),
+            {'AuthTag': 'username', 'Password': 'password', 'Nonce': 'a nonce'})
+        for version in (1, 2):
+            self.assertEqual(
+                juju.apiclient.Connection._login_args(version, 'username', 'password', None),
+                {'auth-tag': 'username', 'credentials': 'password'})
+            self.assertEqual(
+                juju.apiclient.Connection._login_args(version, 'username', 'password', 'a nonce'),
+                {'auth-tag': 'username', 'credentials': 'password', 'nonce': 'a nonce'})
+
+    def test_endpoint(self):
+        address = 'localhost:12345'
+        self.assertEqual(
+            juju.apiclient.Connection._endpoint(address, ''),
+            'wss://localhost:12345')
+        self.assertEqual(
+            juju.apiclient.Connection._endpoint(address, 'env-uuid'),
+            'wss://localhost:12345/environment/env-uuid/api')

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1,0 +1,33 @@
+import mock
+import unittest
+
+import juju.apiclient
+
+
+class TestFacade(unittest.TestCase):
+
+    def test_simple_call_no_version(self):
+        connection = mock.Mock()
+        connection._rpc = mock.Mock(return_value='called')
+
+        facade = juju.apiclient.Facade(connection, "FacadeName")
+        result = facade.SomeMethod('args')
+        self.assertEqual(result, 'called')
+        connection._rpc.assert_called_with('FacadeName', 'SomeMethod', 'args', version=None)
+
+    def test_simple_call_explicit_version(self):
+        connection = mock.Mock()
+        connection._rpc = mock.Mock(return_value='called')
+
+        facade = juju.apiclient.Facade(connection, "FacadeName", 3)
+        result = facade.SomeMethod('args')
+        self.assertEqual(result, 'called')
+        connection._rpc.assert_called_with('FacadeName', 'SomeMethod', 'args', version=3)
+
+
+class TestConnection(unittest.TestCase):
+
+    def test_login_args(self):
+        self.assertEqual(
+            juju.apiclient.Connection._login_args(0, 'username', 'password', None),
+            {"AuthTag": 'username', "Password": 'password'})


### PR DESCRIPTION
Implements the initial API for talking to a Juju server.

Not all aspects of the Connection object are tested at this stage. Wondering how much work would be involved making a fake remote websocket for testing.
